### PR TITLE
using key attribute in map()

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
 import { Component } from 'react';
 import './App.css';
 
-
+// resolving elements should have a unique KEY prop 
+// by adding a unique identifier on each element being rendered
 class App extends Component {
   constructor() {
     super();
@@ -9,13 +10,16 @@ class App extends Component {
     this.state = {
       monsters: [
          {
-          name: 'Linda'
+          name: 'Linda',
+          id: '0001'
          },
          {
-          name: 'Frank'
+          name: 'Frank',
+          id: '0002'
          },
          {
-          name: 'Jacky'
+          name: 'Jacky',
+          id: '0003'
          }
       ],
     };
@@ -27,7 +31,7 @@ class App extends Component {
         {this.state.monsters.map((monster) => {
             return <h1>{monster.name}</h1>;
         })}
-      </div>
+      </div> 
     ); 
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import './App.css';
 
-// resolving elements should have a unique KEY prop 
+// resolving error should have a unique KEY prop 
 // by adding a unique identifier on each element being rendered
 class App extends Component {
   constructor() {
@@ -29,7 +29,7 @@ class App extends Component {
     return (
       <div className="App">
         {this.state.monsters.map((monster) => {
-            return <h1>{monster.name}</h1>;
+            return <h1 key={monster.id}>{monster.name}</h1>;
         })}
       </div> 
     ); 


### PR DESCRIPTION
When updating or re-rendering react elements that is inside a map(), it needs to know which specific element needs updating. 

If we don't provide a key, react will throw this error:
<img width="734" alt="Screenshot 2023-02-21 at 9 54 11 AM" src="https://user-images.githubusercontent.com/36457350/220423279-1238d71a-d6d1-4147-b2d7-a8e2498ea2c3.png">
